### PR TITLE
add dependency for module deployment_script

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -447,4 +447,6 @@ module "deployment_script" {
   subscription_id                     = data.azurerm_client_config.current.subscription_id
   workload_managed_identity_client_id = azurerm_user_assigned_identity.aks_workload_identity.client_id
   tags                                = var.tags
+  
+  depends_on = [ module.aks_cluster ]
 }


### PR DESCRIPTION
Add dependency for module deployment_script on module aks_cluster

## Purpose
* Terraform plan fails for module deployment_scripts
│ Error: Managed Cluster (Subscription: "xxxxxxxx-xxxxxxxx"
│ Resource Group Name: "magic9898ballRG"
│ Managed Cluster Name: "magic9898ballAks") was not found
│ 
│   with module.deployment_script.data.azurerm_kubernetes_cluster.aks_cluster,
│   on modules/deployment_script/main.tf line 14, in data "azurerm_kubernetes_cluster" "aks_cluster":
│   14: data "azurerm_kubernetes_cluster" "aks_cluster" {

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
update terraform.tfvars
terraform init
terraform plan
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
terraform plan
terraform apply
```

## What to Check
Verify that the following are valid
* no error on terraform plan

## Other Information
<!-- Add any other helpful information that may be needed here. -->